### PR TITLE
cache: Column option -k/--key

### DIFF
--- a/preprocess/CMakeLists.txt
+++ b/preprocess/CMakeLists.txt
@@ -30,6 +30,7 @@ foreach(exe ${EXE_LIST})
   set_target_properties(${exe} PROPERTIES FOLDER executables)
 endforeach(exe)
 
+target_link_libraries(cache ${PREPROCESS_LIBS} fields)
 target_link_libraries(shard ${PREPROCESS_LIBS} fields)
 target_link_libraries(substitute ${PREPROCESS_LIBS} fields)
 


### PR DESCRIPTION
Now you can provide column(s) key to use as the deduplication string using -k/--key in the `cache` program. If several, separate them using commas: `cat foo.txt | cache --key 3,4 test.sh`