### PR TITLE
Match regular expression with code comment

### DIFF
--- a/moses/ems/support/split-sentences.perl
+++ b/moses/ems/support/split-sentences.perl
@@ -75,7 +75,7 @@ if (-e "$prefixfile") {
 my $text = "";
 while (<STDIN>) {
 	chomp;
-	if (/^<.+>$/ || /^\s*$/) {
+	if (/^<p>$/ || /^\s*$/) {
 		# Time to process this block; we've hit a blank or <p>
 		&do_it_for($text, $_);
 		print "<P>\n" if (/^\s*$/ && $text); ## If we have text followed by <P>
@@ -93,7 +93,7 @@ while (<STDIN>) {
 sub do_it_for {
 	my($text,$markup) = @_;
 	print &preprocess($text) if $text;
-	print "$markup\n" if ($markup =~ /^<.+>$/);
+	print "$markup\n" if ($markup =~ /^<p>$/);
 	#chop($text);
 }
 


### PR DESCRIPTION
This is supposed to expect a '<p>'  to separate documents, but the regex looks for any tag, creating issues in non-escaped texts.