### PR TITLE
Fix for assertion error when writing exactly 16384 bytes to FakeOFStream

### DIFF
--- a/util/fake_ofstream.hh
+++ b/util/fake_ofstream.hh
@@ -45,7 +45,7 @@ class FakeOFStream {
     }
 
     FakeOFStream &operator<<(StringPiece str) {
-      if (static_cast<std::size_t>(str.size()) > kOutBuf) {
+      if (static_cast<std::size_t>(str.size()) >= kOutBuf) {
         Flush();
         util::WriteOrThrow(fd_, str.data(), str.size());
       } else {


### PR DESCRIPTION
When you write a string of exactly 16384 bytes to a FakeOFStream you hit an assertion in StringBuilder::AddSubstring in [double-conversion/utils.h](https://github.com/kpu/preprocess/blob/38195493e634f1efec0fcd77f6460d47dee13578/util/double-conversion/utils.h#L236).

16384 bytes should just about fit inside the buffer, except that the StringBuilder seems to assume that the last bit is reserved for a `\0`, and all assert statements inside of it follow that assumption.

This fix makes FakeOFStream aware of that behaviour and when you try to write exactly the buffer size it will write it directly instead of going through the buffer.