### PR TITLE
Added a simple program to compute Murmurhash in a md5sum way

### DIFF
--- a/preprocess/CMakeLists.txt
+++ b/preprocess/CMakeLists.txt
@@ -17,6 +17,7 @@ set(EXE_LIST
   docenc
   foldfilter
   gigaword_unwrap
+  mmhsum
   order_independent_hash
   process_unicode
   remove_invalid_utf8

--- a/preprocess/mmhsum_main.cc
+++ b/preprocess/mmhsum_main.cc
@@ -19,8 +19,6 @@ int main(int argc, char *argv[]) {
     size_t count = std::cin.gcount();
     if (!count)
       break;
-    if (std::cin.eof())
-      count -= 1;
     chained_hash = util::MurmurHashNative(buffer, count, chained_hash);
   }
   std::cout << std::hex << chained_hash << '\n';

--- a/preprocess/mmhsum_main.cc
+++ b/preprocess/mmhsum_main.cc
@@ -2,6 +2,8 @@
 
 #include <iostream>
 #include <cstring>
+#include <memory>
+#include <vector>
 
 int main(int argc, char *argv[]) {
   if (argc > 1) {
@@ -10,17 +12,20 @@ int main(int argc, char *argv[]) {
   }
   
   constexpr size_t bufferSize = 1024*1024;
-  char* buffer = new char[bufferSize];
+  std::vector<char> buffer(bufferSize);
   uint64_t chained_hash = 0;
   
   while (std::cin)
   {
-    std::cin.read(buffer, bufferSize);
+    std::cin.read(&buffer[0], bufferSize);
+    if(std::cin.bad()){
+	    std::cerr << "Error trying to read from stdin\n";
+	    return 1;
+    }
     size_t count = std::cin.gcount();
     if (!count)
       break;
-    chained_hash = util::MurmurHashNative(buffer, count, chained_hash);
+    chained_hash = util::MurmurHashNative(&buffer[0], count, chained_hash);
   }
   std::cout << std::hex << chained_hash << '\n';
-  delete[] buffer;
 }

--- a/preprocess/mmhsum_main.cc
+++ b/preprocess/mmhsum_main.cc
@@ -1,0 +1,15 @@
+#include "util/murmur_hash.hh"
+
+#include <iostream>
+
+int main(int argc, char *argv[]) {
+  if (argc > 1) {
+    std::cerr << "Usage: [stdin] " << argv[0] << std::endl;
+    return 1;
+  }
+  std::string input;
+  for (std::string line; std::getline(std::cin, line);) {
+    input += line;
+  }
+  std::cout << std::hex << util::MurmurHashNative(input.c_str(), input.size(), 0) << '\n';
+}

--- a/preprocess/mmhsum_main.cc
+++ b/preprocess/mmhsum_main.cc
@@ -1,15 +1,28 @@
 #include "util/murmur_hash.hh"
 
 #include <iostream>
+#include <cstring>
 
 int main(int argc, char *argv[]) {
   if (argc > 1) {
     std::cerr << "Usage: [stdin] " << argv[0] << std::endl;
     return 1;
   }
-  std::string input;
-  for (std::string line; std::getline(std::cin, line);) {
-    input += line;
+  
+  constexpr size_t bufferSize = 1024*1024;
+  char* buffer = new char[bufferSize];
+  uint64_t chained_hash = 0;
+  
+  while (std::cin)
+  {
+    std::cin.read(buffer, bufferSize);
+    size_t count = std::cin.gcount();
+    if (!count)
+      break;
+    if (std::cin.eof())
+      count -= 1;
+    chained_hash = util::MurmurHashNative(buffer, count, chained_hash);
   }
-  std::cout << std::hex << util::MurmurHashNative(input.c_str(), input.size(), 0) << '\n';
+  std::cout << std::hex << chained_hash << '\n';
+  delete[] buffer;
 }


### PR DESCRIPTION
I couldn't find any 64 bit Murmurhash2 wrapper for Python or in a binary call using the util/murmur_hash.hh `util::MurmurHashNative` function. I made a simple main that reads lines from stdin and prints its mmh2 64bit in hex.

I thought it would be interesting to add it upstream.