### PR TITLE
WIP: batch_dedupe tool to deduplicate across batches

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ find_package(Boost 1.41.0 REQUIRED COMPONENTS
   program_options
   system
   thread
+  filesystem
   unit_test_framework
 )
 

--- a/preprocess/CMakeLists.txt
+++ b/preprocess/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(base64 STATIC base64.cc)
 set(EXE_LIST
   apply_case
   b64filter
+  batch_dedupe
   cache
   commoncrawl_dedupe
   dedupe

--- a/preprocess/batch_dedupe_main.cc
+++ b/preprocess/batch_dedupe_main.cc
@@ -1,5 +1,5 @@
 #include "util/file_piece.hh"
-#include "util/file_stream.hh"
+#include "util/compress.hh"
 #include "util/murmur_hash.hh"
 #include "util/probing_hash_table.hh"
 #include <memory>
@@ -122,7 +122,7 @@ public:
 		// (this also closes the old writers through destruction)
 		for (std::size_t col = 0; col < columns_.size(); ++col) {
 			std::string filename(path.str() + columns_[col]);
-			fhs_[col].reset(new util::FileStream(util::CreateOrThrow(filename.c_str())));
+			fhs_[col].reset(new util::GZipFileStream(util::CreateOrThrow(filename.c_str())));
 			bytes_written_[col] = 0;
 		}
 	}
@@ -165,7 +165,7 @@ public:
 			std::ostringstream path;
 			path << path_ << "/" << batch << "/" << name;
 		
-			util::FileStream fout(util::CreateOrThrow(path.str().c_str())); // todo: compress
+			util::GZipFileStream fout(util::CreateOrThrow(path.str().c_str())); // todo: compress
 			while (begin != end && written < offset) {
 				fout << *begin++ << '\n';
 				++written;
@@ -182,7 +182,7 @@ private:
 	std::vector<std::size_t> batch_offsets_;
 	std::size_t lines_written_;
 	std::vector<std::size_t> bytes_written_;
-	std::vector<std::unique_ptr<util::FileStream>> fhs_;
+	std::vector<std::unique_ptr<util::CompressedFileStream>> fhs_;
 };
 
 struct Entry {

--- a/preprocess/batch_dedupe_main.cc
+++ b/preprocess/batch_dedupe_main.cc
@@ -21,13 +21,13 @@ namespace {
 
 struct Options {
 	std::vector<std::string> batches;
-	std::vector<std::string> combined{"url.gz","source.gz"};
-	std::vector<std::string> derived{"plain_text.gz", "sentences.gz", "sentences_en.gz"};
-	std::string unique{"sentences.gz"};
-	std::string output{"."};
-	std::size_t size{1024 * 1024 * 1024};
-	std::string glue{" "};
-	bool verbose{false};
+	std::vector<std::string> combined;
+	std::vector<std::string> derived;
+	std::string unique;
+	std::string output;
+	std::size_t size;
+	std::string glue;
+	bool verbose;
 };
 
 void ParseArgs(int argc, char *argv[], Options &out) {
@@ -37,10 +37,10 @@ void ParseArgs(int argc, char *argv[], Options &out) {
 		("combined,c", po::value(&out.combined)->multitoken(), "Columns that should be combined")
 		("derived,d", po::value(&out.derived)->multitoken(), "Columns that are derived")
 		("unique,u", po::value(&out.unique), "Column to deduplicate on")
-		("output,o", po::value(&out.output), "Output path")
-		("bytes,b", po::value(&out.size), "Maximum batch size")
-		("glue,g", po::value(&out.glue), "Glue between combined values")
-		("verbose,v", po::bool_switch(&out.verbose), "Print progress updates")
+		("output,o", po::value(&out.output)->default_value("."), "Output path")
+		("bytes,b", po::value(&out.size)->default_value(1024 * 1024 * 1024), "Maximum batch size")
+		("glue,g", po::value(&out.glue)->default_value(" "), "Glue between combined values")
+		("verbose,v", po::bool_switch(&out.verbose)->default_value(false), "Print progress updates")
 		("help,h", "Produce help message");
 
 	po::options_description hidden("Hidden options");

--- a/preprocess/batch_dedupe_main.cc
+++ b/preprocess/batch_dedupe_main.cc
@@ -95,8 +95,7 @@ private:
 // Joins (and thus blocks) on destruction.
 class AsyncWriter {
 public:
-	AsyncWriter(int fh)
-	: queue_(kOperationQueueSize) {
+	AsyncWriter(int fh) {
 		auto &queue = queue_;
 		writer_  = std::thread([&queue, fh]() {
 			util::GZipFileStream fout(fh);
@@ -123,9 +122,7 @@ public:
 	}
 
 private:
-	// Arbitrary number, but in my tests kept memory usage around 2GB.
-	static const std::size_t kOperationQueueSize = 8192;
-	util::PCQueue<std::string> queue_;
+	util::UnboundedSingleQueue<std::string> queue_;
 	std::thread writer_;
 };
 

--- a/preprocess/batch_dedupe_main.cc
+++ b/preprocess/batch_dedupe_main.cc
@@ -64,8 +64,7 @@ void ParseArgs(int argc, char *argv[], Options &out) {
 class Reader {
 public:
 	Reader(std::string const &path, std::vector<std::string> const &columns)
-	: path_(path)
-	{
+	: path_(path) {
 		fhs_.reserve(columns.size());
 
 		// Open all columns at the same time in the same order as `columns`
@@ -95,7 +94,8 @@ private:
 // Joins (and thus blocks) on destruction.
 class AsyncWriter {
 public:
-	AsyncWriter(int fh) {
+	AsyncWriter(int fh)
+	: file_(fh) {
 		auto &queue = queue_;
 		writer_  = std::thread([&queue, fh]() {
 			util::GZipFileStream fout(fh);
@@ -124,6 +124,7 @@ public:
 private:
 	util::UnboundedSingleQueue<std::string> queue_;
 	std::thread writer_;
+	util::scoped_fd file_;
 };
 
 // Batch writer: writes unique columns on the go, will rotate files if any of
@@ -138,8 +139,7 @@ public:
 		limit_(limit),
 		lines_written_(0),
 		bytes_written_(columns.size(), limit + 1), // force rotate at start
-		fhs_(columns.size())
-	{
+		fhs_(columns.size()) {
 		//
 	}
 

--- a/preprocess/batch_dedupe_main.cc
+++ b/preprocess/batch_dedupe_main.cc
@@ -1,0 +1,298 @@
+#include "util/file_piece.hh"
+#include "util/file_stream.hh"
+#include "util/murmur_hash.hh"
+#include "util/probing_hash_table.hh"
+#include <memory>
+#include <numeric>
+#include <string>
+#include <unordered_set>
+#include <vector>
+#include <boost/filesystem.hpp>
+#include <boost/program_options/options_description.hpp>
+#include <boost/program_options/parsers.hpp>
+#include <boost/program_options/variables_map.hpp>
+#include <boost/iterator/transform_iterator.hpp>
+
+namespace {
+
+struct Options {
+	std::vector<std::string> batches;
+	std::vector<std::string> combined{"url.gz","source.gz"};
+	std::vector<std::string> derived{"plain_text.gz", "sentences.gz", "sentences_en.gz"};
+	std::string unique{"sentences.gz"};
+	std::string output{"."};
+	std::size_t size{1024 * 1024 * 1024};
+	std::string glue{" "};
+};
+
+void ParseArgs(int argc, char *argv[], Options &out) {
+	namespace po = boost::program_options;
+	po::options_description visible("Batch options");
+	visible.add_options()
+		("combined,c", po::value(&out.combined)->multitoken(), "Columns that should be combined")
+		("derived,d", po::value(&out.derived)->multitoken(), "Columns that are derived")
+		("unique,u", po::value(&out.unique), "Column to deduplicate on")
+		("output,o", po::value(&out.output), "Output path")
+		("bytes,b", po::value(&out.size), "Maximum batch size")
+		("glue,g", po::value(&out.glue), "Glue between combined values")
+		("help,h", "Produce help message");
+
+	po::options_description hidden("Hidden options");
+	hidden.add_options()
+		("input-file,i", po::value(&out.batches), "Input batches");
+
+	po::positional_options_description positional;
+	positional.add("input-file", -1);
+
+	po::options_description opts;
+	opts.add(visible).add(hidden);
+
+	po::variables_map vm;
+	po::store(po::command_line_parser(argc, argv).options(opts).positional(positional).run(), vm);
+	po::notify(vm);
+
+	if (vm.count("help")) {
+		std::cerr << "Usage: [options] <path/to/batch> [<path> ...]" << "\n"
+		          << "\n" << visible << "\n";
+		std::exit(1);
+	}
+
+	std::cerr << "Unique column:" << out.unique << "\n";
+	std::cerr << "\nColumns to combine with '" << out.glue << "':\n";
+	for (std::string const &column : out.combined)
+		std::cerr << "- " << column << "\n";
+	std::cerr << "\nColumns to keep only one value of:\n";
+	for (std::string const &column : out.derived)
+		std::cerr << "- " << column << "\n";
+}
+
+class Reader {
+public:
+	Reader(std::string const &path, std::vector<std::string> const &columns)
+	: path_(path),
+		columns_(columns)
+	{
+		fhs_.reserve(columns.size());
+
+		for (auto &&column : columns) {
+			std::string filename(path + "/" + column);
+			fhs_.emplace_back(filename.c_str());
+		}
+	}
+
+	bool ReadRowOrEOF(std::vector<util::StringPiece> &row) {
+		row.resize(fhs_.size());
+
+		for (std::size_t col = 0; col < fhs_.size(); ++col)
+			if (!fhs_[col].ReadLineOrEOF(row[col]))
+				return false;
+
+		return true;
+	}
+
+private:
+	std::string path_;
+	std::vector<std::string> columns_;
+	std::vector<util::FilePiece> fhs_;
+};
+
+class Writer {
+public:
+	Writer(std::string const &path, std::vector<std::string> const &columns, std::size_t limit)
+	: path_(path),
+		columns_(columns),
+		limit_(limit),
+		lines_written_(0),
+		bytes_written_(columns.size(), limit + 1), // force rotate at start
+		fhs_(columns.size())
+	{
+		//
+	}
+
+	void Rotate() {
+		// Store where we are now
+		batch_offsets_.push_back(lines_written_);
+
+		// Todo: use boost::filesystem::path?
+		std::ostringstream path;
+		path << path_ << "/" << batch_offsets_.size() << "/";
+		boost::filesystem::create_directories(path.str());
+
+		// Open columns in the new batch and reset write counters
+		// (this also closes the old writers through destruction)
+		for (std::size_t col = 0; col < columns_.size(); ++col) {
+			std::string filename(path.str() + columns_[col]);
+			fhs_[col].reset(new util::FileStream(util::CreateOrThrow(filename.c_str())));
+			bytes_written_[col] = 0;
+		}
+	}
+
+	template <typename It> std::size_t WriteRow(It begin, It end) {
+		assert(std::distance(begin, end) == columns_.size());
+
+		// Check whether writing any of the columns would push us over the size limit
+		auto written_it = bytes_written_.begin();
+		for (auto it = begin; it != end; ++it) {
+			if (*written_it++ + it->size() + 1 > limit_) {
+				Rotate();
+				break; // Don't rotate multiple times
+			}
+		}
+
+		auto fh_it = fhs_.begin();
+		written_it = bytes_written_.begin();
+		for (auto it = begin; it != end; ++it) {
+			*(*fh_it++) << *it << '\n';
+			*written_it++ += it->size() + 1; // plus newline
+		}
+
+		return lines_written_++;
+	}
+
+	template <typename It> void WriteColumn(std::string const &name, It begin, It end) {
+		std::size_t batch = 0;
+		std::size_t written = 0;
+		std::size_t offset;
+
+		// Yes this will start batches counting from 1 instead of 0. But so did
+		// giashard. Let's keep that legacy around for a bit longer.
+		for (std::size_t batch = 1; begin != end; ++batch) {
+			if (batch < batch_offsets_.size())
+				offset = batch_offsets_[batch];
+			else
+				offset = lines_written_ + 1; // or maxint, just something out of reach
+
+			std::ostringstream path;
+			path << path_ << "/" << batch << "/" << name;
+		
+			util::FileStream fout(util::CreateOrThrow(path.str().c_str())); // todo: compress
+			while (begin != end && written < offset) {
+				fout << *begin++ << '\n';
+				++written;
+			}
+		}
+
+		UTIL_THROW_IF2(written != lines_written_, "WriteColumn(" << name << ") wrote " << written << " rows, expected " << lines_written_ << " rows");
+	}
+
+private:
+	std::string path_; // path to directory where batches are written to
+	std::vector<std::string> columns_;
+	std::size_t limit_; // filesize limit per batch
+	std::vector<std::size_t> batch_offsets_;
+	std::size_t lines_written_;
+	std::vector<std::size_t> bytes_written_;
+	std::vector<std::unique_ptr<util::FileStream>> fhs_;
+};
+
+struct Entry {
+	typedef uint64_t Key;
+	uint64_t key;
+	std::size_t offset;
+	uint64_t GetKey() const { return key; }
+	void SetKey(uint64_t to) { key = to; }
+};
+
+template <typename T, typename V> std::size_t FindIndex(T const &container, V const &needle) {
+	std::size_t index = 0;
+	
+	for (auto &&value : container) {
+		if (value == needle)
+			break;
+		++index;
+	}
+
+	return index;
+}
+
+// Needlessly complicated string concatenation operator that does only one
+// memory allocation if I got it right.
+struct Concat {
+	std::string glue;
+
+	Concat(std::string const &glue) : glue(glue) {
+		//
+	}
+
+	std::string operator()(std::unordered_set<std::string> const &values) const {
+		std::size_t glue_size = glue.size();
+
+		std::size_t size = std::accumulate(values.begin(), values.end(), 0,
+			[glue_size](std::size_t size, std::string const &value) {
+				return size + value.size() + glue_size; //` plus a space
+			});
+
+		if (size == 0)
+			return std::string();
+
+		std::string out;
+		out.reserve(size - glue_size); // Glue only between, so -1
+
+		auto it = values.begin();
+		out.append(*it);
+		while (++it != values.end()) {
+			out.append(glue);
+			out.append(*it);
+		}
+
+		assert(out.size() == size - glue_size); // Did I get it right?
+
+		return out;
+	}
+};
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+	Options options;
+	ParseArgs(argc, argv, options);
+
+	std::size_t unique = FindIndex(options.derived, options.unique);
+	UTIL_THROW_IF2(unique == options.derived.size(), "unique column has to be part of derived columns");
+
+	Writer fout(".", options.derived, 1024 * 1024 * 1024);
+
+	typedef util::AutoProbing<Entry, util::IdentityHash> Table;
+	Table table;
+
+	std::vector<std::string> columns(options.derived.size() + options.combined.size());
+	std::copy(options.combined.begin(), options.combined.end(),
+		std::copy(options.derived.begin(), options.derived.end(),
+			columns.begin()));
+
+	// For each combined column, for each unqiue row, we have a set of values.
+	// Using std::string instead of StringPiece here because StringPiece doesnt
+	// own its memory, and Reader will have progressed when we need these strings
+	// again.
+	std::vector<std::vector<std::unordered_set<std::string>>> combined_column_values(options.combined.size());
+
+	std::vector<util::StringPiece> row(columns.size());
+
+	for (auto &&path : options.batches) {
+		Reader batch(path, columns);
+		while (batch.ReadRowOrEOF(row)) {
+			Entry entry;
+			entry.key = util::MurmurHashNative(row[unique].begin(), row[unique].size()) + 1;
+			
+			Table::MutableIterator it;
+			if (!table.FindOrInsert(entry, it)) {
+				it->offset = fout.WriteRow(row.begin(), row.begin() + options.derived.size());
+				
+				for (std::size_t col = 0; col < options.combined.size(); ++col)
+					combined_column_values[col].emplace_back(); // Add a new set
+			}
+
+			for (std::size_t col = 0; col < options.combined.size(); ++col) {
+				util::StringPiece const &value = row[options.derived.size() + col];
+				combined_column_values[col][it->offset].insert(std::string(value.data(), value.size()));
+			}
+		}
+	}
+
+	for (std::size_t col = 0; col < options.combined.size(); ++col)
+		fout.WriteColumn(options.combined[col],
+			boost::make_transform_iterator(combined_column_values[col].begin(), Concat(options.glue)), 
+			boost::make_transform_iterator(combined_column_values[col].end(), Concat(options.glue)));
+
+	return 0;
+}

--- a/preprocess/batch_dedupe_main.cc
+++ b/preprocess/batch_dedupe_main.cc
@@ -205,7 +205,8 @@ public:
 			std::ostringstream path;
 			path << path_ << "/" << batch << "/" << name;
 		
-			util::GZipFileStream fout(util::CreateOrThrow(path.str().c_str()));
+			util::scoped_fd fd(util::CreateOrThrow(path.str().c_str()));
+			util::GZipFileStream fout(fd.get());
 			while (begin != end && written < offset) {
 				fout << *begin++ << '\n';
 				++written;

--- a/preprocess/batch_dedupe_main.cc
+++ b/preprocess/batch_dedupe_main.cc
@@ -56,14 +56,6 @@ void ParseArgs(int argc, char *argv[], Options &out) {
 		          << "\n" << visible << "\n";
 		std::exit(1);
 	}
-
-	std::cerr << "Unique column:" << out.unique << "\n";
-	std::cerr << "\nColumns to combine with '" << out.glue << "':\n";
-	for (std::string const &column : out.combined)
-		std::cerr << "- " << column << "\n";
-	std::cerr << "\nColumns to keep only one value of:\n";
-	for (std::string const &column : out.derived)
-		std::cerr << "- " << column << "\n";
 }
 
 class Reader {

--- a/preprocess/batch_dedupe_main.cc
+++ b/preprocess/batch_dedupe_main.cc
@@ -290,7 +290,7 @@ int main(int argc, char *argv[]) {
 	std::size_t unique = FindIndex(options.derived, options.unique);
 	UTIL_THROW_IF2(unique == options.derived.size(), "unique column has to be part of derived columns");
 
-	Writer fout(".", options.derived, 1024 * 1024 * 1024);
+	Writer fout(options.output, options.derived, 1024 * 1024 * 1024);
 
 	typedef util::AutoProbing<Entry, util::IdentityHash> Table;
 	Table table;

--- a/util/compress.hh
+++ b/util/compress.hh
@@ -3,6 +3,7 @@
 
 #include "util/exception.hh"
 #include "util/scoped.hh"
+#include "util/compressed_file_stream.hh"
 
 #include <cstddef>
 #include <stdint.h>
@@ -91,6 +92,11 @@ class ReadCompressed {
 // Very basic gzip compression support.  Normally this would involve streams
 // but I needed the compression in the thread with fused output.
 void GZCompress(StringPiece from, std::string &to, int level = 9);
+
+class GZipFileStream : public CompressedFileStream {
+public:
+  explicit GZipFileStream(int out = -1, int level = 9, std::size_t buffer_size = 8192);
+};
 
 } // namespace util
 

--- a/util/compressed_file_stream.hh
+++ b/util/compressed_file_stream.hh
@@ -1,0 +1,141 @@
+#ifndef UTIL_COMPRESSED_FILE_STREAM_H
+#define UTIL_COMPRESSED_FILE_STREAM_H
+
+#include "util/fake_ostream.hh"
+#include "util/file.hh"
+#include "util/scoped.hh"
+#include "util/compress.hh"
+
+#include <memory>
+#include <cassert>
+#include <cstring>
+
+#include <stdint.h>
+
+namespace util {
+
+class Compressor {
+public:
+  virtual ~Compressor() = 0;
+
+  virtual void SetOutput(void *to, std::size_t amount) = 0;
+  virtual void SetInput(const void *base, std::size_t amount) = 0;
+  virtual const void* GetOutput() const = 0;
+
+  virtual void Process() = 0;
+  virtual bool HasInput() const = 0;
+  virtual bool OutOfSpace() const = 0;
+  virtual bool Finish() = 0;
+};
+
+inline Compressor::~Compressor() {
+  // Pure virtual destructor, still needs implementation.
+}
+
+class CompressedFileStream : public FakeOStream<CompressedFileStream> {
+  public:
+    explicit CompressedFileStream(std::unique_ptr<Compressor> compressor, int out = -1, std::size_t buffer_size = 8192)
+      : compressor_(std::move(compressor)),
+        buf_(util::MallocOrThrow(std::max<std::size_t>(buffer_size, kToStringMaxBytes))),
+        compressed_(util::MallocOrThrow(std::max<std::size_t>(buffer_size, kToStringMaxBytes))),
+        compressed_size_(std::max<std::size_t>(buffer_size, kToStringMaxBytes)),
+        current_(static_cast<char*>(buf_.get())),
+        end_(current_ + std::max<std::size_t>(buffer_size, kToStringMaxBytes)),
+        fd_(out)
+        {
+          compressor_->SetOutput(compressed_.get(), compressed_size_);
+        }
+
+    // <missing move constructor>
+
+    ~CompressedFileStream() {
+      finish();
+    }
+
+    void SetFD(int to) {
+      finish();
+      fd_ = to;
+    }
+
+    CompressedFileStream &finish() {
+      flush();
+      FinishCompressed();
+      return *this;
+    }
+
+    CompressedFileStream &flush() {
+      if (current_ != buf_.get()) {
+        WriteCompressed(buf_.get(), current_ - (char*) buf_.get());
+        current_ = static_cast<char*>(buf_.get());
+      }
+      return *this;
+    }
+
+    // For writes of arbitrary size.
+    CompressedFileStream &write(const void *data, std::size_t length) {
+      if (UTIL_LIKELY(current_ + length <= end_)) {
+        std::memcpy(current_, data, length);
+        current_ += length;
+        return *this;
+      }
+      flush();
+      if (current_ + length <= end_) {
+        std::memcpy(current_, data, length);
+        current_ += length;
+      } else {
+        WriteCompressed(data, length);
+      }
+      return *this;
+    }
+
+  protected:
+    friend class FakeOStream<CompressedFileStream>;
+    // For writes directly to buffer guaranteed to have amount < buffer size.
+    char *Ensure(std::size_t amount) {
+      if (UTIL_UNLIKELY(current_ + amount > end_)) {
+        flush();
+        assert(current_ + amount <= end_);
+      }
+      return current_;
+    }
+
+    void AdvanceTo(char *to) {
+      current_ = to;
+      assert(current_ <= end_);
+    }
+
+  private:
+    void WriteCompressed(const void *data, std::size_t length) {
+      compressor_->SetInput(data, length);
+      while (compressor_->HasInput()) {
+        if (compressor_->OutOfSpace())
+          FlushCompressed();
+        compressor_->Process();
+      }
+    }
+
+    void FlushCompressed() {
+      std::size_t compressed_len = reinterpret_cast<const char*>(compressor_->GetOutput()) - reinterpret_cast<const char*>(compressed_.get());
+      util::WriteOrThrow(fd_, compressed_.get(), compressed_len);
+      compressor_->SetOutput(compressed_.get(), compressed_size_);
+    }
+
+    void FinishCompressed() {
+      // Generate last bit of compressed output
+      do {
+        FlushCompressed();
+      } while (!compressor_->Finish());
+      // Write ending
+      FlushCompressed();
+    }
+    
+    util::scoped_malloc buf_, compressed_;
+    std::size_t compressed_size_;
+    char *current_, *end_;
+    int fd_;
+    std::unique_ptr<Compressor> compressor_;
+};
+
+} // namespace
+
+#endif


### PR DESCRIPTION
Reads through all batches in a shard but only writes unique entries:
- whether the entry is unique is determined by hashing the base64-encoded line of sentences.gz
- plain_text.gz, sentences.gz and sentences_en.gz are written only once per duplicate
- source.gz and url.gz keep all the unique values across the duplicate entries, and are written separated by spaces (assuming we don't use spaces in filenames, and they don't occur in the URLs we extracted from the WARC headers.)
- Write gzipped and split into batches of 1G (uncompressed)
- All of the above is configurable

What's not so great:
- Piggybacks on GzipWrite from compress.cc. No idea if this interface makes sense in the long run.

Opening pull request early for feedback 😬