### PR TITLE
Use self-pipe trick to teleport execvp failure from fork to parent

### DIFF
--- a/preprocess/captive_child.cc
+++ b/preprocess/captive_child.cc
@@ -7,6 +7,7 @@
 #ifdef __linux__
 #include <sys/prctl.h>
 #endif
+#include <fcntl.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
@@ -28,6 +29,17 @@ pid_t Launch(char *argv[], util::scoped_fd &in, util::scoped_fd &out) {
   util::scoped_fd process_in, process_out;
   Pipe(process_in, in);
   Pipe(out, process_out);
+
+  // Using self-pipe trick to check whether execvp did not fail: Set up a pipe
+  // with FD_CLOEXEC (close on successful exec). In case of failure, we'll
+  // write something to the pipe and close it manually. Then, in the parent we
+  // can wait till the pipe is closed: either execvp succeeded and we read
+  // nothing or we read our error code and throw an exception in the parent.
+  // (See https://stackoverflow.com/a/1586277)
+  util::scoped_fd status_in, status_out;
+  Pipe(status_in, status_out);
+  UTIL_THROW_IF(fcntl(status_out.get(), F_SETFD, fcntl(status_out.get(), F_GETFD) | FD_CLOEXEC), util::ErrnoException, "fcntl failed");
+
   pid_t pid = fork();
   UTIL_THROW_IF(pid == -1, util::ErrnoException, "Fork failed");
   if (pid == 0) {
@@ -39,11 +51,22 @@ pid_t Launch(char *argv[], util::scoped_fd &in, util::scoped_fd &out) {
     UTIL_THROW_IF(-1 == dup2(process_out.get(), STDOUT_FILENO), util::ErrnoException, "dup2 failed for process stdout from " << process_out.get());
     in.reset();
     out.reset();
+    status_in.reset();
     execvp(argv[0], argv);
-    util::ErrnoException e;
-    std::cerr << "exec " << argv[0] << " failed: " << e.what() << std::endl;
-    abort();
+    // Oh no, execvp failed, write error to parent
+    write(status_out.get(), &errno, sizeof(int));
+    std::abort();
   }
+  status_out.reset();
+
+  // Wait on child to signal successful execvp or error
+  int count, err;
+  while ((count = read(*status_in, &err, sizeof(errno))) == -1)
+    if (errno != EAGAIN && errno != EINTR)
+      break;
+
+  UTIL_THROW_IF(count != 0, util::Exception, "child's execvp failed: " << strerror(err));
+  
   // Parent closes parts it doesn't need in destructors.
   return pid;
 }


### PR DESCRIPTION
Issue #27 seems to be caused by only the fork aborting, but the parent never knowing the fork is dead until it tries to interact with its pipes.

This work-around uses FD_CLOEXEC to use another pipe to check whether the child did launch the wrapped executable, or whether it failed. This error is then transmitted back to the parent, throwing an exception. That will then neatly stop the parent from beginning to read/block on stdin.