### PR TITLE
Catch eof exception in cache when output is empty

### DIFF
--- a/preprocess/cache_main.cc
+++ b/preprocess/cache_main.cc
@@ -94,11 +94,11 @@ void Output(util::UnboundedSingleQueue<QueueEntry> &queue, util::scoped_fd &proc
     try {
       if (!value.data()) {
         // New entry, not cached.
-        StringPiece got = in.ReadLine();
+        util::StringPiece got = in.ReadLine();
         // Allocate memory to store a copy of the line.
         char *copy_to = (char *) string_pool.Allocate(got.size());
         memcpy(copy_to, got.data(), got.size());
-        value = StringPiece(copy_to, got.size());
+        value = util::StringPiece(copy_to, got.size());
       }
       out << value << '\n';
     }

--- a/preprocess/cache_main.cc
+++ b/preprocess/cache_main.cc
@@ -91,15 +91,18 @@ void Output(util::UnboundedSingleQueue<QueueEntry> &queue, util::scoped_fd &proc
   QueueEntry q;
   while (queue.Consume(q).value) {
     util::StringPiece &value = *q.value;
-    if (!value.data()) {
-      // New entry, not cached.
-      util::StringPiece got = in.ReadLine();
-      // Allocate memory to store a copy of the line.
-      char *copy_to = (char*)string_pool.Allocate(got.size());
-      memcpy(copy_to, got.data(), got.size());
-      value = util::StringPiece(copy_to, got.size());
+    try {
+      if (!value.data()) {
+        // New entry, not cached.
+        StringPiece got = in.ReadLine();
+        // Allocate memory to store a copy of the line.
+        char *copy_to = (char *) string_pool.Allocate(got.size());
+        memcpy(copy_to, got.data(), got.size());
+        value = StringPiece(copy_to, got.size());
+      }
+      out << value << '\n';
     }
-    out << value << '\n';
+    catch (const util::EndOfFileException& e){}
   }
 }
 


### PR DESCRIPTION
Running
```
echo "test" | cache echo -n
```
crashes with 
```
terminate called after throwing an instance of 'util::EndOfFileException'
  what():  End of file
Aborted (core dumped)
```

This is something I got in a bigger scale while using Marian over a document with only very long lines (Marian didn't translate any of them, and didn't write even an endline character. I guess this is a known behaviour).