### PR TITLE
Prob hash table reserve

### DIFF
--- a/util/mmap.hh
+++ b/util/mmap.hh
@@ -82,6 +82,14 @@ class scoped_memory {
       : data_(from.data_), size_(from.size_), source_(from.source_) {
       from.steal();
     }
+
+    scoped_memory &operator=(scoped_memory &&from) noexcept {
+      reset();
+      size_ = from.size_;
+      source_ = from.source_;
+      data_ = from.steal();
+      return *this;
+    }
 #endif
 
     ~scoped_memory() { reset(); }

--- a/util/probing_hash_table.hh
+++ b/util/probing_hash_table.hh
@@ -393,10 +393,19 @@ template <class EntryT, class HashT, class EqualT = std::equal_to<typename Entry
       return backend_.RawEnd();
     }
 
+    void Reserve(size_t capacity) {
+      while (threshold_ < capacity)
+        Double();
+    }
+
   private:
     void DoubleIfNeeded() {
       if (UTIL_LIKELY(Size() < threshold_))
         return;
+      Double();
+    }
+
+    void Double() {
       HugeRealloc(backend_.DoubleTo(), KeyIsRawZero(backend_.invalid_), mem_);
       allocated_ = backend_.DoubleTo();
       backend_.Double(mem_.get(), !KeyIsRawZero(backend_.invalid_));


### PR DESCRIPTION
Adds a `Reserve()` method to `AutoProbing` that is necessary to get Bitextor's document aligner to work with this type of table.

I tried multiple setups where I just initialised the main table with a different size, but [making sure the destination table is large enough](https://github.com/jelmervdl/bitextor/pull/3/files#diff-c77e45a678b69e01aef380e83f0fe09a26647c2259d01c73741b31f8d1efcee0R111-R135) with a `Reserve` call seems to be the only way to have any predictably good performance.

I also added a move-assignment operator to `scoped_memory`, the lack thereof prevented me to do `df = std::move(local_df)`.

Things that can be improved:
- I didn't check if `AutoProbing`'s auto-generated move assignment operator is up to the job, but the output seems to be as expected. The `AutoProbing` table that was moved out from might be in a funny state though, with its counters not reset and no backing memory left.
- `Reserve()` is just a while-loop around `Double()`, which is the laziest implementation possible but does a couple of pointless realloc calls.